### PR TITLE
remove azureedge.net from blocklistBLOATWAREPiHoleIndonesia

### DIFF
--- a/blocklistBLOATWAREPiHoleIndonesia_byAdam4wan.txt
+++ b/blocklistBLOATWAREPiHoleIndonesia_byAdam4wan.txt
@@ -100,7 +100,6 @@ download-installer.cdn.mozilla.net
 ||vivo.com^
 ||vivo.com.cn^
 ||facemojikeyboard.com^
-||azureedge.net^
 ||appcenter.ms^
 ||microsoftapp.net^
 ||finzfin.com^


### PR DESCRIPTION
ngerusak vscode extension, jadi gak bisa download

![image](https://github.com/user-attachments/assets/2932df45-07a3-4326-adad-2a30ecbb26d4)
